### PR TITLE
fix error for np.int

### DIFF
--- a/Demo4/init_utils.py
+++ b/Demo4/init_utils.py
@@ -183,7 +183,7 @@ def predict(X, y, parameters):
     """
     
     m = X.shape[1]
-    p = np.zeros((1,m), dtype = np.int)
+    p = np.zeros((1,m), dtype = int)
     
     # Forward propagation
     a3, caches = forward_propagation(X, parameters)


### PR DESCRIPTION
in new version of numpy it said that you have to use int instead of np.int